### PR TITLE
update sharp for upgrading libvips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "minio": "^7.0.25",
         "mongodb": "^4.3.0",
         "multer": "^1.4.4",
-        "sharp": "^0.29.3",
+        "sharp": "^0.30.3",
         "socket.io": "^4.3.1",
         "typescript": "^4.4.4",
         "uuid": "^8.3.2",
@@ -33,7 +33,7 @@
         "@types/config": "0.0.40",
         "@types/express": "^4.17.13",
         "@types/node": "^16.11.1",
-        "@types/sharp": "^0.29.5",
+        "@types/sharp": "^0.30.0",
         "@types/uuid": "^8.3.1",
         "ts-node": "^10.3.0"
       }
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@types/sharp": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.29.5.tgz",
-      "integrity": "sha512-3TC+S3H5RwnJmLYMHrcdfNjz/CaApKmujjY9b6PU/pE6n0qfooi99YqXGWoW8frU9EWYj/XTI35Pzxa+ThAZ5Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.30.0.tgz",
+      "integrity": "sha512-bZ0Y/JVlrOyqwlBMJ2taEgnwFavjLnyZmLOLecmOesuG5kR2Lx9b2fM4osgfVjLJi8UlE+t3R1JzRVMxF6MbfA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -932,14 +932,11 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
       }
     },
     "node_modules/dicer": {
@@ -2211,14 +2208,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/prebuild-install/node_modules/detect-libc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2499,17 +2488,17 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
-      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.3.tgz",
+      "integrity": "sha512-rjpfJFK58ZOFSG8sxYSo3/JQb4ej095HjXp9X7gVu7gEn1aqSG8TCW29h/Rr31+PXrFADo1H/vKfw0uhMQWFtg==",
       "hasInstallScript": true,
       "dependencies": {
-        "color": "^4.0.1",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0",
+        "color": "^4.2.1",
+        "detect-libc": "^2.0.1",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1",
         "semver": "^7.3.5",
-        "simple-get": "^4.0.0",
+        "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       },
@@ -3330,9 +3319,9 @@
       }
     },
     "@types/sharp": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.29.5.tgz",
-      "integrity": "sha512-3TC+S3H5RwnJmLYMHrcdfNjz/CaApKmujjY9b6PU/pE6n0qfooi99YqXGWoW8frU9EWYj/XTI35Pzxa+ThAZ5Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.30.0.tgz",
+      "integrity": "sha512-bZ0Y/JVlrOyqwlBMJ2taEgnwFavjLnyZmLOLecmOesuG5kR2Lx9b2fM4osgfVjLJi8UlE+t3R1JzRVMxF6MbfA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3953,9 +3942,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
     "dicer": {
       "version": "0.2.5",
@@ -4920,13 +4909,6 @@
         "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "detect-libc": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-          "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
-        }
       }
     },
     "process-nextick-args": {
@@ -5152,16 +5134,16 @@
       }
     },
     "sharp": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
-      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.3.tgz",
+      "integrity": "sha512-rjpfJFK58ZOFSG8sxYSo3/JQb4ej095HjXp9X7gVu7gEn1aqSG8TCW29h/Rr31+PXrFADo1H/vKfw0uhMQWFtg==",
       "requires": {
-        "color": "^4.0.1",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0",
+        "color": "^4.2.1",
+        "detect-libc": "^2.0.1",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1",
         "semver": "^7.3.5",
-        "simple-get": "^4.0.0",
+        "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "minio": "^7.0.25",
     "mongodb": "^4.3.0",
     "multer": "^1.4.4",
-    "sharp": "^0.29.3",
+    "sharp": "^0.30.3",
     "socket.io": "^4.3.1",
     "typescript": "^4.4.4",
     "uuid": "^8.3.2",
@@ -35,7 +35,7 @@
     "@types/config": "0.0.40",
     "@types/express": "^4.17.13",
     "@types/node": "^16.11.1",
-    "@types/sharp": "^0.29.5",
+    "@types/sharp": "^0.30.0",
     "@types/uuid": "^8.3.1",
     "ts-node": "^10.3.0"
   }


### PR DESCRIPTION
一部PNG画像の処理中に Input buffer has corrupt header: pngload_buffer: too many text chunks のエラーが出てしまう問題への対応となります。

ref. https://github.com/lovell/sharp/issues/2917